### PR TITLE
fix: sw interception only on root page

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -59,6 +59,21 @@ export default defineNuxtConfig({
 			clientsClaim: true,
 			navigateFallback: '/',
 			globPatterns: ['**/*.{js,css,html,png,svg,ico,json}'],
+			navigateFallbackAllowlist: [/\/$/],
+			runtimeCaching: [{
+				urlPattern: ({ request, sameOrigin, url }) => {
+					// eslint-disable-next-line no-console
+					console.log(url)
+					return sameOrigin && (request.mode === 'navigate' || /^\/api\//.test(url.pathname))
+				},
+				handler: 'NetworkOnly',
+				options: {
+					plugins: [{
+						handlerDidError: async () => Response.redirect('/?error', 302),
+						cacheWillUpdate: async () => null,
+					}],
+				},
+			}],
 		},
 		devOptions: {
 			enabled: true,


### PR DESCRIPTION
Can you try with this configuration? Since you are using build, there is no 404.html page, you can include and prerender it, then redirect in the runtimeCaching handler to `/404`.

When offline, any ssr page navigation or server api call will use network only, if there is an error [handlerDidError](https://github.com/vincentdorian/nuxt-pwa-with-auth/pull/1/files#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R72) will be called (the redirection can only be done to a page in the sw precache manifest, if missing you will get infinite redirection loop if offline) and so it will not fail (browser offline page will not be there if navigating). You can also check if there is a response, you can just return the response, otherwise redirect.